### PR TITLE
Add github workflow to run unit tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: cd workspace && npm run test
+      env:
+        CI: true


### PR DESCRIPTION
@JohannesHoppe 
It would be cool to create a status badge for the UTs for the README.
But first we need to create a github workflow for running the UTs.
That is what this PR is about. 

Normally there should show up a new Action after the merge, see screenshot
![image](https://user-images.githubusercontent.com/1272446/100734181-8c4c7580-33cf-11eb-851b-c9cfe66d003e.png)

We can then copy paste the status badge code to the README.
