### PR TITLE
Safari Support

### DIFF
--- a/workspace/package-lock.json
+++ b/workspace/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@12core/date-input-polyfill": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@12core/date-input-polyfill/-/date-input-polyfill-3.1.1.tgz",
+      "integrity": "sha512-07fzWngy8bVXa+k+3gq2gO50mrt0gXuk9BFAa8fy2hPp5RLreZdRpqIXY0aLeZ5Jw6/mVxDi+P8jbzelFPgBug==",
+      "requires": {
+        "dateformat": "^4.3.1"
+      }
+    },
     "@ampproject/remapping": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-1.0.1.tgz",
@@ -3449,11 +3457,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "configurable-date-input-polyfill": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/configurable-date-input-polyfill/-/configurable-date-input-polyfill-2.7.2.tgz",
-      "integrity": "sha512-s2kdlrogNwXxbLFOmDxVXbWTKkohF7AuC3LQSb+q6e8gUCd+p/cYsy/m/yTUs1y0Cy/691Yks1aDjFZavB/yhQ=="
-    },
     "connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -3969,6 +3972,11 @@
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
       "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
       "dev": true
+    },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
     },
     "debug": {
       "version": "4.1.1",

--- a/workspace/package.json
+++ b/workspace/package.json
@@ -14,6 +14,7 @@
   },
   "private": true,
   "dependencies": {
+    "@12core/date-input-polyfill": "^3.1.1",
     "@angular/animations": "~13.0.2",
     "@angular/common": "~13.0.2",
     "@angular/compiler": "~13.0.2",
@@ -22,7 +23,6 @@
     "@angular/platform-browser": "~13.0.2",
     "@angular/platform-browser-dynamic": "~13.0.2",
     "@angular/router": "~13.0.2",
-    "configurable-date-input-polyfill": "^2.7.2",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"

--- a/workspace/projects/date-value-accessor/package.json
+++ b/workspace/projects/date-value-accessor/package.json
@@ -29,9 +29,11 @@
   "homepage": "https://github.com/johanneshoppe/angular-date-value-accessor",
   "peerDependencies": {
     "@angular/common": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
-    "@angular/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
+    "@angular/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@12core/date-input-polyfill": "^3.1.1"
   },
   "dependencies": {
+    "@12core/date-input-polyfill": "^3.1.1",
     "tslib": "^2.0.0"
   }
 }

--- a/workspace/projects/date-value-accessor/src/lib/date-value-accessor-polyfill.module.ts
+++ b/workspace/projects/date-value-accessor/src/lib/date-value-accessor-polyfill.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { DateValueAccessorPolyfill } from './date-value-accessor-polyfill';
+
+@NgModule({
+  declarations: [DateValueAccessorPolyfill],
+  exports: [DateValueAccessorPolyfill]
+})
+export class DateValueAccessorPolyfillModule { }

--- a/workspace/projects/date-value-accessor/src/lib/date-value-accessor-polyfill.ts
+++ b/workspace/projects/date-value-accessor/src/lib/date-value-accessor-polyfill.ts
@@ -1,0 +1,30 @@
+import { Directive } from "@angular/core";
+import '@12core/date-input-polyfill/dist/date-input-polyfill.esm';
+import { Input } from '@12core/date-input-polyfill/dist/date-input-polyfill.esm'
+
+
+/**
+ * The original polyfill patches controls on DOMContentLoaded and body.mousedown
+ * but not when Angular adds elements to DOM
+ * see https://github.com/little-core-labs/date-input-polyfill/blob/master/src/date-input-polyfill.js
+ *
+ * This directives makes sure all our date input controls are patched before first usage
+ */
+@Directive({
+  selector: '[useValueAsDate],[useValueAsLocalDate],[useValueAsIso],[useValueAsLocalIso]'
+})
+export class DateValueAccessorPolyfill {
+  constructor() {
+    if (!Input.supportsDateInput()) {
+      Input.addPickerToDateInputs()
+    }
+  }
+}
+
+// https://stackoverflow.com/a/31732310
+export function isSafari() {
+  return navigator.vendor && navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.userAgent &&
+    navigator.userAgent.indexOf('CriOS') == -1 &&
+    navigator.userAgent.indexOf('FxiOS') == -1;
+}

--- a/workspace/projects/date-value-accessor/src/public-api.ts
+++ b/workspace/projects/date-value-accessor/src/public-api.ts
@@ -11,3 +11,6 @@ export * from './lib/iso-date-value-accessor';
 export * from './lib/iso-date-value-accessor.module';
 export * from './lib/local-iso-date-value-accessor';
 export * from './lib/local-iso-date-value-accessor.module';
+
+export * from './lib/date-value-accessor-polyfill';
+export * from './lib/date-value-accessor-polyfill.module';

--- a/workspace/projects/demo/.browserslistrc
+++ b/workspace/projects/demo/.browserslistrc
@@ -14,5 +14,3 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
-IE 9-10 # Angular support for IE 9-10 has been deprecated and will be removed as of Angular v11. To opt-in, remove the 'not' prefix on this line.
-IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.

--- a/workspace/projects/demo/src/app/app.module.ts
+++ b/workspace/projects/demo/src/app/app.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { IsoDateValueAccessorModule } from 'projects/date-value-accessor/src/lib/iso-date-value-accessor.module';
 import {
   DateValueAccessorModule,
+  DateValueAccessorPolyfillModule,
+  IsoDateValueAccessorModule,
   LocalDateValueAccessorModule,
   LocalIsoDateValueAccessorModule,
 } from 'projects/date-value-accessor/src/public-api';
@@ -42,7 +43,8 @@ import { ExplanationLocalIsoDateValueAccessorComponent } from './shared/explanat
     DateValueAccessorModule,
     LocalDateValueAccessorModule,
     IsoDateValueAccessorModule,
-    LocalIsoDateValueAccessorModule
+    LocalIsoDateValueAccessorModule,
+    DateValueAccessorPolyfillModule
   ],
   bootstrap: [AppComponent]
 })

--- a/workspace/projects/demo/src/app/demo-with-dates/reactive-form/reactive-form.component.html
+++ b/workspace/projects/demo/src/app/demo-with-dates/reactive-form/reactive-form.component.html
@@ -68,7 +68,7 @@ typeof(releaseDate): {{ typeof(demoLocalDateValue.releaseDate) }}
 
 <app-explanation-default-value-accessor></app-explanation-default-value-accessor>
 
-<div class="bad">
+<div class="bad" *ngIf="!isSafari">
   <h2>DefaultValueAccessor<br><small>(does not work)</small></h2>
 
   <form [formGroup]="myFormDefault">
@@ -94,4 +94,8 @@ DEBUG:
 {{ demoDefault | json }}
 typeof(releaseDate): {{ typeof(demoDefault.releaseDate) }}
 </pre>
+</div>
+
+<div class="bad" *ngIf="isSafari">
+  Sorry, we disabled the demo of Angular's original DefaultValueAccessor <strong>on Safari</strong> because it causes an error at runtime.
 </div>

--- a/workspace/projects/demo/src/app/demo-with-dates/reactive-form/reactive-form.component.ts
+++ b/workspace/projects/demo/src/app/demo-with-dates/reactive-form/reactive-form.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { isSafari } from 'projects/date-value-accessor/src/public-api';
 
 import { Release } from '../../shared/release';
 
@@ -16,6 +17,8 @@ export class ReactiveFormComponent implements OnInit {
   myFormDateValue: FormGroup;
   myFormLocalDateValue: FormGroup;
   myFormDefault: FormGroup;
+
+  isSafari = isSafari();
 
   constructor(private fb: FormBuilder) {
     this.demoDateValue = new Release('2.0.0', new Date('2020-01-01')); // UTC

--- a/workspace/projects/demo/src/app/demo-with-dates/template-driven-form/template-driven-form.component.html
+++ b/workspace/projects/demo/src/app/demo-with-dates/template-driven-form/template-driven-form.component.html
@@ -72,7 +72,7 @@ typeof(releaseDate): {{ typeof(demoLocalDateValue.releaseDate) }}
 
 <app-explanation-default-value-accessor></app-explanation-default-value-accessor>
 
-<div class="bad">
+<div class="bad" *ngIf="!isSafari">
   <h2>DefaultValueAccessor<br><small>(does not work)</small></h2>
 
   <form>
@@ -102,3 +102,6 @@ typeof(releaseDate): {{ typeof(demoDefault.releaseDate) }}
 </pre>
 </div>
 
+<div class="bad" *ngIf="isSafari">
+  Sorry, we disabled the demo of Angular's original DefaultValueAccessor <strong>on Safari</strong> because it causes an error at runtime.
+</div>

--- a/workspace/projects/demo/src/app/demo-with-dates/template-driven-form/template-driven-form.component.ts
+++ b/workspace/projects/demo/src/app/demo-with-dates/template-driven-form/template-driven-form.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { isSafari } from 'projects/date-value-accessor/src/public-api';
+
 import { Release } from '../../shared/release';
 
 @Component({
@@ -14,6 +16,8 @@ export class TemplateDrivenFormComponent {
   demoDateValueDisabled = false;
   demoLocalDateValueDisabled = false;
   demoDefaultDisabled = false;
+
+  isSafari = isSafari();
 
   constructor() {
     this.demoDateValue = new Release('2.0.0', new Date('2020-01-01')); // UTC

--- a/workspace/projects/demo/src/app/demo-with-strings/reactive-form-iso/reactive-form-iso.component.html
+++ b/workspace/projects/demo/src/app/demo-with-strings/reactive-form-iso/reactive-form-iso.component.html
@@ -66,7 +66,7 @@ typeof(releaseDate): {{ typeof(demoLocalIsoDateValue.releaseDate) }}
 
 <hr>
 
-<div class="bad">
+<div class="bad" *ngIf="!isSafari">
   <h2>DefaultValueAccessor<br><small>(does not work)</small></h2>
 
   <form [formGroup]="myFormDefault">
@@ -92,4 +92,8 @@ DEBUG:
 {{ demoIsoDefault | json }}
 typeof(releaseDate): {{ typeof(demoIsoDefault.releaseDate) }}
 </pre>
+</div>
+
+<div class="bad" *ngIf="isSafari">
+  Sorry, we disabled the demo of Angular's original DefaultValueAccessor <strong>on Safari</strong> because it causes an error at runtime.
 </div>

--- a/workspace/projects/demo/src/app/demo-with-strings/reactive-form-iso/reactive-form-iso.component.ts
+++ b/workspace/projects/demo/src/app/demo-with-strings/reactive-form-iso/reactive-form-iso.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { isSafari } from 'projects/date-value-accessor/src/public-api';
 
 import { ReleaseWithIsoString } from '../../shared/release-with-iso-string';
 
@@ -16,6 +17,8 @@ export class ReactiveFormIsoComponent implements OnInit {
   myFormDateValue: FormGroup;
   myFormDefault: FormGroup;
   myFormLocalDateValue: FormGroup;
+
+  isSafari = isSafari();
 
   constructor(private fb: FormBuilder) {
     this.demoIsoDateValue = new ReleaseWithIsoString('2.0.0', new Date('2020-01-01').toISOString()); // UTC

--- a/workspace/projects/demo/src/app/demo-with-strings/template-driven-form-iso/template-driven-form-iso.component.html
+++ b/workspace/projects/demo/src/app/demo-with-strings/template-driven-form-iso/template-driven-form-iso.component.html
@@ -71,7 +71,7 @@ typeof(releaseDate): {{ typeof(demoLocalIsoDateValue.releaseDate) }}
 
 <hr>
 
-<div class="bad">
+<div class="bad" *ngIf="!isSafari">
   <h2>DefaultValueAccessor<br><small>(does not work)</small></h2>
 
   <form>
@@ -101,3 +101,6 @@ typeof(releaseDate): {{ typeof(demoIsoDefault.releaseDate) }}
 </pre>
 </div>
 
+<div class="bad" *ngIf="isSafari">
+  Sorry, we disabled the demo of Angular's original DefaultValueAccessor <strong>on Safari</strong> because it causes an error at runtime.
+</div>

--- a/workspace/projects/demo/src/app/demo-with-strings/template-driven-form-iso/template-driven-form-iso.component.ts
+++ b/workspace/projects/demo/src/app/demo-with-strings/template-driven-form-iso/template-driven-form-iso.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { isSafari } from 'projects/date-value-accessor/src/public-api';
+
 import { ReleaseWithIsoString } from '../../shared/release-with-iso-string';
 
 @Component({
@@ -14,6 +16,8 @@ export class TemplateDrivenFormIsoComponent {
   demoIsoDateValueDisabled = false;
   demoLocalIsoDateValueDisabled = false;
   demoIsoDefaultDisabled = false;
+
+  isSafari = isSafari();
 
   constructor() {
     this.demoIsoDateValue = new ReleaseWithIsoString('2.0.0', new Date('2020-01-01').toISOString()); // UTC

--- a/workspace/projects/demo/src/polyfills.ts
+++ b/workspace/projects/demo/src/polyfills.ts
@@ -51,4 +51,3 @@ import 'zone.js';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
-import 'configurable-date-input-polyfill';


### PR DESCRIPTION
This is proof of work, I successfully patched date input controls on my old Safari. But it's not ready for use. As specified in the README of the polyfill project:

> Date objects are displayed in the **local time zone**, which causes date drift by a day sometimes. Looking into this issue now.
> source: https://github.com/little-core-labs/date-input-polyfill

![2021-11-19 10 46 36](https://user-images.githubusercontent.com/640639/142602969-8f1cc833-b370-40ff-96f4-bbc3aaa3fa8b.gif)

This screws up the produced dates completely, so it would be required to add the offset manually – but only for Safari. This means some extra work, but it's definitely doable. We can now recommend the DateValueAccessor to our readers without any restrictions, it will (**soon**) work in all browsers without any concerns.

FYI @fmalcher @d-koppenhagen