### PR TITLE
lift peerDeps to Angular 14.0.0

### DIFF
--- a/workspace/projects/date-value-accessor/package.json
+++ b/workspace/projects/date-value-accessor/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/johanneshoppe/angular-date-value-accessor",
   "peerDependencies": {
-    "@angular/common": ">= 9.0.0",
-    "@angular/core": ">= 9.0.0"
+    "@angular/common": ">= 14.0.0",
+    "@angular/core": ">= 14.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
Older versions are not compatible with Standalone Directives